### PR TITLE
Retrain the LinearRegressor to add X2

### DIFF
--- a/xgboost/LinearAndQuadraticFunctionRegression/quadratic_xgboost_localmode.ipynb
+++ b/xgboost/LinearAndQuadraticFunctionRegression/quadratic_xgboost_localmode.ipynb
@@ -1352,6 +1352,7 @@
     "y = quad_func(X)\n",
     "df_tmp = pd.DataFrame({'x':X,'y':y,'x2':X**2})\n",
     "df_tmp['xgboost']=regressor.predict(df_tmp[['x']])\n",
+    "lin_regressor.fit(X = df_tmp[['x','x2']], y = y)\n",
     "df_tmp['linear']=lin_regressor.predict(df_tmp[['x','x2']])"
    ]
   },


### PR DESCRIPTION
On the "Solution for under-fitting" part we need to retrain the LinearRegressor model to use both 'x' and 'x2' as inputs, or else it will show an error.  I added the retrain line on the corresponding cell.